### PR TITLE
hotfix: 리뷰 0개일 때 예외 발생 수정

### DIFF
--- a/api/src/main/java/shop/ink3/api/book/book/service/BookService.java
+++ b/api/src/main/java/shop/ink3/api/book/book/service/BookService.java
@@ -3,6 +3,7 @@ package shop.ink3.api.book.book.service;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
@@ -274,7 +275,8 @@ public class BookService {
     }
 
     private double getAverageRating(Long bookId) {
-        return reviewRepository.findAverageRatingByBookId(bookId);
+        return reviewRepository.findAverageRatingByBookId(bookId)
+            .orElse(0.0);
     }
     // 카테고리는 최소 2단계
 

--- a/api/src/main/java/shop/ink3/api/review/review/repository/ReviewRepository.java
+++ b/api/src/main/java/shop/ink3/api/review/review/repository/ReviewRepository.java
@@ -1,5 +1,7 @@
 package shop.ink3.api.review.review.repository;
 
+import java.util.Optional;
+
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -59,5 +61,5 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
             JOIN r.orderBook ob
             WHERE ob.book.id = :bookId
         """)
-    Double findAverageRatingByBookId(@Param("bookId") Long bookId);
+    Optional<Double> findAverageRatingByBookId(@Param("bookId") Long bookId);
 }

--- a/api/src/test/java/shop/ink3/api/book/book/service/BookServiceTest.java
+++ b/api/src/test/java/shop/ink3/api/book/book/service/BookServiceTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -61,7 +62,7 @@ class BookServiceTest {
     @DisplayName("도서 단건 조회 성공")
     void getBookSuccess() {
         when(bookRepository.findById(1L)).thenReturn(java.util.Optional.of(book));
-        when(reviewRepository.findAverageRatingByBookId(1L)).thenReturn(4.5);
+        when(reviewRepository.findAverageRatingByBookId(1L)).thenReturn(Optional.of(4.5));
 
         BookResponse result = bookService.getBook(1L);
         assertThat(result.id()).isEqualTo(1L);


### PR DESCRIPTION
## 개요
- 리뷰가 0개일 때 평점이 NullPointerException 발생해서 null이 아닌 0.0을 반환하도록 수정했습니다.

![스크린샷 2025-06-03 오후 4 44 30](https://github.com/user-attachments/assets/2eb26a77-20d9-4f10-ba82-2b1f93f02be0)

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.  Commit message convention 참고  (Ctrl + 클릭하세요.) 
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
